### PR TITLE
fixed event update bug

### DIFF
--- a/code/backend/api/events/serializers.py
+++ b/code/backend/api/events/serializers.py
@@ -78,6 +78,7 @@ class EventSerializer(serializers.ModelSerializer):
             if field in validated_data:
                 update = True
                 setattr(body, field, validated_data[field])
+                body.save()
         if update:
             request = self.context.get('request')
             event_activity_handler(type="Update", actor=request.user, object=instance)


### PR DESCRIPTION
There was a bug where the updating an event using the relevant endpoint did not actually altered data in the database. This was due a misuse of referencing properties of python objects. This is a simple fix.